### PR TITLE
lint: fix some errors found by cppcheck v1.67

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -253,6 +253,7 @@ int get_start(struct global *G)
 	if ((rf = fopen(oldf, "r")) != NULL)
 		rename(oldf, G->runf);
 	free(oldf);
+	fclose(rf);
 
 	if ((rf = fopen(G->runf, "r")) == NULL) {
 		

--- a/src/utils/common.c
+++ b/src/utils/common.c
@@ -578,6 +578,7 @@ int pingen_zhaochunsheng(char *mac, int add)
 
     strcpy(bssid_copy, mac);
     bssid_parts = strtok(bssid_copy, ":");
+    free(bssid_copy);
 
     while(bssid_parts)
     {

--- a/src/wps/wps_registrar.c
+++ b/src/wps/wps_registrar.c
@@ -2495,7 +2495,7 @@ static enum wps_process_res wps_process_wsc_msg(struct wps_data *wps,
 	if (*attr.msg_type != WPS_M1 &&
 	    (attr.registrar_nonce == NULL ||
 	     os_memcmp(wps->nonce_r, attr.registrar_nonce,
-		       WPS_NONCE_LEN != 0))) {
+		       WPS_NONCE_LEN) != 0)) {
 		wpa_printf(MSG_DEBUG, "WPS: Mismatch in registrar nonce");
 		return WPS_FAILURE;
 	}
@@ -2586,14 +2586,14 @@ static enum wps_process_res wps_process_wsc_ack(struct wps_data *wps,
 #endif /* CONFIG_WPS_UPNP */
 
 	if (attr.registrar_nonce == NULL ||
-	    os_memcmp(wps->nonce_r, attr.registrar_nonce, WPS_NONCE_LEN != 0))
+	    os_memcmp(wps->nonce_r, attr.registrar_nonce, WPS_NONCE_LEN) != 0)
 	{
 		wpa_printf(MSG_DEBUG, "WPS: Mismatch in registrar nonce");
 		return WPS_FAILURE;
 	}
 
 	if (attr.enrollee_nonce == NULL ||
-	    os_memcmp(wps->nonce_e, attr.enrollee_nonce, WPS_NONCE_LEN != 0)) {
+	    os_memcmp(wps->nonce_e, attr.enrollee_nonce, WPS_NONCE_LEN) != 0) {
 		wpa_printf(MSG_DEBUG, "WPS: Mismatch in enrollee nonce");
 		return WPS_FAILURE;
 	}
@@ -2660,14 +2660,14 @@ static enum wps_process_res wps_process_wsc_nack(struct wps_data *wps,
 #endif /* CONFIG_WPS_UPNP */
 
 	if (attr.registrar_nonce == NULL ||
-	    os_memcmp(wps->nonce_r, attr.registrar_nonce, WPS_NONCE_LEN != 0))
+	    os_memcmp(wps->nonce_r, attr.registrar_nonce, WPS_NONCE_LEN) != 0)
 	{
 		wpa_printf(MSG_DEBUG, "WPS: Mismatch in registrar nonce");
 		return WPS_FAILURE;
 	}
 
 	if (attr.enrollee_nonce == NULL ||
-	    os_memcmp(wps->nonce_e, attr.enrollee_nonce, WPS_NONCE_LEN != 0)) {
+	    os_memcmp(wps->nonce_e, attr.enrollee_nonce, WPS_NONCE_LEN) != 0) {
 		wpa_printf(MSG_DEBUG, "WPS: Mismatch in enrollee nonce");
 		return WPS_FAILURE;
 	}
@@ -2747,14 +2747,14 @@ static enum wps_process_res wps_process_wsc_done(struct wps_data *wps,
 #endif /* CONFIG_WPS_UPNP */
 
 	if (attr.registrar_nonce == NULL ||
-	    os_memcmp(wps->nonce_r, attr.registrar_nonce, WPS_NONCE_LEN != 0))
+	    os_memcmp(wps->nonce_r, attr.registrar_nonce, WPS_NONCE_LEN) != 0)
 	{
 		wpa_printf(MSG_DEBUG, "WPS: Mismatch in registrar nonce");
 		return WPS_FAILURE;
 	}
 
 	if (attr.enrollee_nonce == NULL ||
-	    os_memcmp(wps->nonce_e, attr.enrollee_nonce, WPS_NONCE_LEN != 0)) {
+	    os_memcmp(wps->nonce_e, attr.enrollee_nonce, WPS_NONCE_LEN) != 0) {
 		wpa_printf(MSG_DEBUG, "WPS: Mismatch in enrollee nonce");
 		return WPS_FAILURE;
 	}


### PR DESCRIPTION
I used `cppcheck` v1.67 to fix some errors.

**Issues fixed** 

```
src/utils.c:257: error (resourceLeak): Resource leak: rf
src/utils/common.c:599: error (memleak): Memory leak: bssid_copy
src/wps/wps_registrar.c:2498: error (invalidFunctionArgBool): Invalid memcmp() argument nr 3. A non-boolean value is required.
src/wps/wps_registrar.c:2589: error (invalidFunctionArgBool): Invalid memcmp() argument nr 3. A non-boolean value is required.
src/wps/wps_registrar.c:2596: error (invalidFunctionArgBool): Invalid memcmp() argument nr 3. A non-boolean value is required.
src/wps/wps_registrar.c:2663: error (invalidFunctionArgBool): Invalid memcmp() argument nr 3. A non-boolean value is required.
src/wps/wps_registrar.c:2670: error (invalidFunctionArgBool): Invalid memcmp() argument nr 3. A non-boolean value is required.
src/wps/wps_registrar.c:2750: error (invalidFunctionArgBool): Invalid memcmp() argument nr 3. A non-boolean value is required.
src/wps/wps_registrar.c:2757: error (invalidFunctionArgBool): Invalid memcmp() argument nr 3. A non-boolean value is required.
```

**Remaining issues found**

```
$ cppcheck --template "{file}:{line}: {severity} ({id}): {message}" \
  --quiet --force --enable=warning ./src/                           \
  | cut -d: -f3 | sort | uniq -c | sort -n
      1  warning (nullPointer)
      2  error (arrayIndexOutOfBounds)
      2  error (va_list_usedBeforeStarted)
      2  warning (invalidPrintfArgType_sint)
      2  warning (invalidscanf)
```

**Going further**

You might also want to enable style checks by using `--enable=style` instead of `--enable=warning`.

Furthermore, I think it would make sense to create a `tools` folder and add a BASH script like `cppcheck.sh` to it, in order to make finding these kind of defects easier. If this is something you want, I can create a respective pull request.